### PR TITLE
Fix/auto install pillow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+django-grappelli>=2.12,<2.13
+pillow

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,9 @@ from setuptools import setup, find_packages
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
+with open('requirements.txt', 'r') as f:
+    REQUIREMENTS = f.readlines()
+
 setup(
     name='django-filebrowser',
     version='3.11.1',
@@ -32,8 +35,5 @@ setup(
         'Programming Language :: Python :: 3.6',
     ],
     zip_safe=False,
-    install_requires=[
-        'django-grappelli>=2.12,<2.13',
-        'pillow',
-    ],
+    install_requires=REQUIREMENTS,
 )

--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,6 @@ setup(
     zip_safe=False,
     install_requires=[
         'django-grappelli>=2.12,<2.13',
+        'pillow',
     ],
 )


### PR DESCRIPTION
It ensures that `pillow` is processed as a requirement at installation time.

Also provides an isolated `requirements.txt` file, to "~humanize" and standardize the requirements definition.

Related to #370 Ensure that pillow is installed as a requirement
